### PR TITLE
Patch to include the Oberbank

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,5 +24,9 @@ CSV statements from these banks are currently supported:
 * Raiffeisenbank (CSV)
 
   - Giro account
+  
+* Oberbank (CSV)
+
+  - Giro account
 
 .. _ofxstatement: https://github.com/kedder/ofxstatement

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(name="ofxstatement-austrian",
       long_description=long_description,
       license="GPLv3",
       keywords=[
-          "ofxstatement", "easybank", "ing-diba", "livebank", "raiffeisen", "oberbank"],
+          "ofxstatement", "easybank", "ing-diba",
+          "livebank", "raiffeisen", "oberbank"],
       classifiers=[
           "Development Status :: 3 - Alpha",
           "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name="ofxstatement-austrian",
       long_description=long_description,
       license="GPLv3",
       keywords=[
-          "ofxstatement", "easybank", "ing-diba", "livebank", "raiffeisen"],
+          "ofxstatement", "easybank", "ing-diba", "livebank", "raiffeisen", "oberbank"],
       classifiers=[
           "Development Status :: 3 - Alpha",
           "Programming Language :: Python :: 3",
@@ -43,6 +43,7 @@ setup(name="ofxstatement-austrian",
               "ing-diba = ofxstatement.plugins.ingdiba:IngDiBaPlugin",
               "livebank = ofxstatement.plugins.livebank:LivebankPlugin",
               "raiffeisen = ofxstatement.plugins.raiffeisen:RaiffeisenPlugin",
+              "oberbank = ofxstatement.plugins.oberbank:OberbankPlugin"
           ]
       },
       install_requires=["ofxstatement"],

--- a/src/ofxstatement/plugins/oberbank.py
+++ b/src/ofxstatement/plugins/oberbank.py
@@ -34,6 +34,10 @@ class OberbankCsvParser(CsvStatementParser):
 
     def parse_record(self, line):
         """Parse a single record."""
+        # Skip header line
+        if self.cur_record == 1:
+            return None
+
         # Currency
         if not self.statement.currency:
             self.statement.currency = line[3]

--- a/src/ofxstatement/plugins/oberbank.py
+++ b/src/ofxstatement/plugins/oberbank.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# This file is part of ofxstatement-austrian.
+# See README.rst for more information.
+
+import csv
+from ofxstatement import statement
+from ofxstatement.parser import CsvStatementParser
+from ofxstatement.plugin import Plugin
+from ofxstatement.statement import generate_transaction_id
+from ofxstatement.plugins.utils import \
+    clean_multiple_whitespaces, fix_amount_string
+
+
+class OberbankCsvParser(CsvStatementParser):
+    """The csv parser for Oberbank."""
+
+    date_format = "%d.%m.%Y"
+
+    mappings = {
+        "date": 0,
+        "memo": 10,
+        "amount": 2,
+        }
+
+    def parse(self):
+        """Parse."""
+        stmt = super(OberbankCsvParser, self).parse()
+        statement.recalculate_balance(stmt)
+        return stmt
+
+    def split_records(self):
+        """Split records using a custom dialect."""
+        return csv.reader(self.fin, delimiter=";")
+
+    def parse_record(self, line):
+        """Parse a single record."""
+        # Currency
+        if not self.statement.currency:
+            self.statement.currency = line[3]
+
+        # Cleanup parts
+        line[2] = fix_amount_string(line[2])
+        line[10] = clean_multiple_whitespaces(line[10])
+
+        # Create statement and fixup missing parts
+        stmtline = super(OberbankCsvParser, self).parse_record(line)
+        stmtline.trntype = 'DEBIT' if stmtline.amount < 0 else 'CREDIT'
+        stmtline.id = generate_transaction_id(stmtline)
+
+        return stmtline
+
+
+class OberbankPlugin(Plugin):
+    """Oberbank (CSV)"""
+
+    def get_parser(self, filename):
+        """Get a parser instance."""
+        encoding = self.settings.get('charset', 'cp1252')
+        f = open(filename, 'r', encoding=encoding)
+        parser = OberbankCsvParser(f)
+        parser.statement.account_id = self.settings.get('account', 'default')
+        parser.statement.bank_id = self.settings.get('bank', 'Oberbank')
+        return parser
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent autoindent

--- a/src/ofxstatement/plugins/tests/samples/Umsatzübersicht_20170315_AT022050302101023600.csv
+++ b/src/ofxstatement/plugins/tests/samples/Umsatzübersicht_20170315_AT022050302101023600.csv
@@ -1,0 +1,7 @@
+Buchungsdatum;Wertstellung;Betrag;Währung;Auftraggebername;Auftraggeber IBAN/Kto.Nr.;Auftraggeber BIC/BLZ;Empfängername;Empfänger IBAN/Kto.Nr.;Empfänger BIC/BLZ;Text;Verwendungszweck
+15.03.2017;15.03.2017;-11,00;EUR;;;;;;;Zahlungsreferenz, Empfängername, Adresszeile1, Adresszeile2;
+15.03.2017;15.03.2017;-10,00;EUR;;;;;;;Verwendungszweck, Empfängername, Adresszeile1, Adresszeile2, Verwendungszweck, VerwendungszweckZeile2, VerwendungszweckZeile3, VerwendungszweckZeile4;
+15.03.2017;15.03.2017;-9,00;EUR;;;;;;;End2EndID, Empfängername, Adresszeile1, Adresszeile2;
+15.03.2017;15.03.2017;11,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
+15.03.2017;15.03.2017;10,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
+15.03.2017;15.03.2017;9,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck

--- a/src/ofxstatement/plugins/tests/samples/Umsatzübersicht_20170315_AT022050302101023600.csv
+++ b/src/ofxstatement/plugins/tests/samples/Umsatzübersicht_20170315_AT022050302101023600.csv
@@ -1,7 +1,0 @@
-Buchungsdatum;Wertstellung;Betrag;Währung;Auftraggebername;Auftraggeber IBAN/Kto.Nr.;Auftraggeber BIC/BLZ;Empfängername;Empfänger IBAN/Kto.Nr.;Empfänger BIC/BLZ;Text;Verwendungszweck
-15.03.2017;15.03.2017;-11,00;EUR;;;;;;;Zahlungsreferenz, Empfängername, Adresszeile1, Adresszeile2;
-15.03.2017;15.03.2017;-10,00;EUR;;;;;;;Verwendungszweck, Empfängername, Adresszeile1, Adresszeile2, Verwendungszweck, VerwendungszweckZeile2, VerwendungszweckZeile3, VerwendungszweckZeile4;
-15.03.2017;15.03.2017;-9,00;EUR;;;;;;;End2EndID, Empfängername, Adresszeile1, Adresszeile2;
-15.03.2017;15.03.2017;11,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
-15.03.2017;15.03.2017;10,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
-15.03.2017;15.03.2017;9,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck

--- a/src/ofxstatement/plugins/tests/samples/oberbank.csv
+++ b/src/ofxstatement/plugins/tests/samples/oberbank.csv
@@ -1,0 +1,8 @@
+Buchungsdatum;Wertstellung;Betrag;Währung;Auftraggebername;Auftraggeber IBAN/Kto.Nr.;Auftraggeber BIC/BLZ;Empfängername;Empfänger IBAN/Kto.Nr.;Empfänger BIC/BLZ;Text;Verwendungszweck
+28.06.13;01.07.13;0,58;EUR;;;;;;;0,125 % p.a. Habenzinsen ab 01.04.13;
+28.06.13;01.07.13;-0,15;EUR;;;;;;;Kapitalertragsteuer;
+28.06.13;01.07.13;-0,11;EUR;;;;;;;Entgelt Kontoauszug;
+28.06.13;01.07.13;-6,65;EUR;;;;;;;Entgelt Kontoführung;
+01.07.13;01.07.13;-175,16;EUR;;;;;;;ELBA-INTERNET VOM 29.06 UM 09:16  Empfänger:  A person  Verwendungszweck:  Invoice number 10;
+01.07.13;01.07.13;-100;EUR;;;;;;;Lastschrift  Auftraggeber:  A company  Kundendaten:  000000000000 111111111111  Verwendungszweck:  reason;
+04.07.13;04.07.13;123,6;EUR;;;;;;;Gutschrift Auftraggeber: A person Kundendaten: reason;

--- a/src/ofxstatement/plugins/tests/samples/oberbank.csv
+++ b/src/ofxstatement/plugins/tests/samples/oberbank.csv
@@ -1,8 +1,7 @@
 Buchungsdatum;Wertstellung;Betrag;Währung;Auftraggebername;Auftraggeber IBAN/Kto.Nr.;Auftraggeber BIC/BLZ;Empfängername;Empfänger IBAN/Kto.Nr.;Empfänger BIC/BLZ;Text;Verwendungszweck
-28.06.13;01.07.13;0,58;EUR;;;;;;;0,125 % p.a. Habenzinsen ab 01.04.13;
-28.06.13;01.07.13;-0,15;EUR;;;;;;;Kapitalertragsteuer;
-28.06.13;01.07.13;-0,11;EUR;;;;;;;Entgelt Kontoauszug;
-28.06.13;01.07.13;-6,65;EUR;;;;;;;Entgelt Kontoführung;
-01.07.13;01.07.13;-175,16;EUR;;;;;;;ELBA-INTERNET VOM 29.06 UM 09:16  Empfänger:  A person  Verwendungszweck:  Invoice number 10;
-01.07.13;01.07.13;-100;EUR;;;;;;;Lastschrift  Auftraggeber:  A company  Kundendaten:  000000000000 111111111111  Verwendungszweck:  reason;
-04.07.13;04.07.13;123,6;EUR;;;;;;;Gutschrift Auftraggeber: A person Kundendaten: reason;
+15.03.2017;15.03.2017;-11,00;EUR;;;;;;;Zahlungsreferenz, Empfängername, Adresszeile1, Adresszeile2;
+15.03.2017;15.03.2017;-10,00;EUR;;;;;;;Verwendungszweck, Empfängername, Adresszeile1, Adresszeile2, Verwendungszweck, VerwendungszweckZeile2, VerwendungszweckZeile3, VerwendungszweckZeile4;
+15.03.2017;15.03.2017;-9,00;EUR;;;;;;;End2EndID, Empfängername, Adresszeile1, Adresszeile2;
+15.03.2017;15.03.2017;11,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
+15.03.2017;15.03.2017;10,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck
+15.03.2017;15.03.2017;9,00;EUR;Auftraggebername;AT022050302101023601;PBNKDEFF;Empfängername Empfängeradresse;AT022050302101023600;PBNKDEFG;Empfängername, SCOR, Verwendungszweck;SCOR Verwendungszweck


### PR DESCRIPTION
Warning: This is my first commit, and I am not fluent in Python. I have mainly modified the existing raiffeisen plugin to make it read my Oberbank file.

Problems:
I could not figure out how to tell ofxstatement to delete the first line (which contains the colum names). So if you do not delete the first line with the colum names, you will get an error, similar to the one attached.

I have not modified the test case, so one for Oberbank is still missing.
[error.txt](https://github.com/nblock/ofxstatement-austrian/files/850171/error.txt)

Thanks in advance for looking at this!