### PR TITLE
Raiffeisen Mein Elba now exports utf-8 CSV files

### DIFF
--- a/src/ofxstatement/plugins/raiffeisen.py
+++ b/src/ofxstatement/plugins/raiffeisen.py
@@ -55,7 +55,7 @@ class RaiffeisenPlugin(Plugin):
 
     def get_parser(self, filename):
         """Get a parser instance."""
-        encoding = self.settings.get('charset', 'cp1252')
+        encoding = self.settings.get('charset', 'utf-8-sig')
         f = open(filename, 'r', encoding=encoding)
         parser = RaiffeisenCsvParser(f)
         parser.statement.account_id = self.settings.get('account', 'default')


### PR DESCRIPTION
Mein Elba now produces CSV files with UTF-8 and a BOM:
```
$ file meinelba_umsaetze_AT_______.csv
meinelba_umsaetze_AT_______.csv: UTF-8 Unicode (with BOM) text, with very long lines
```

This changes the encoding to account for that.